### PR TITLE
Refactor MermaidGenerator to enhance diff status representation

### DIFF
--- a/src/main/mermaid_generator.ts
+++ b/src/main/mermaid_generator.ts
@@ -59,14 +59,24 @@ export class MermaidGenerator extends UmlGenerator {
     [Icon.NONE]: "",
   };
 
-  // Static mapping from DiffStatus to prefix
-  private static readonly DIFF_STATUS_PREFIX_MAP: Record<
+  // Static mapping from DiffStatus to prefix symbol
+  private static readonly DIFF_STATUS_SYMBOL_MAP: Record<
     flowTypes.DiffStatus,
     string
   > = {
-    [flowTypes.DiffStatus.ADDED]: "➕",
-    [flowTypes.DiffStatus.DELETED]: "❌",
-    [flowTypes.DiffStatus.MODIFIED]: "✏️",
+    [flowTypes.DiffStatus.ADDED]: "+",
+    [flowTypes.DiffStatus.DELETED]: "-",
+    [flowTypes.DiffStatus.MODIFIED]: "Δ",
+  };
+
+  // Static mapping from DiffStatus to color
+  private static readonly DIFF_STATUS_COLOR_MAP: Record<
+    flowTypes.DiffStatus,
+    string
+  > = {
+    [flowTypes.DiffStatus.ADDED]: "green",
+    [flowTypes.DiffStatus.DELETED]: "red",
+    [flowTypes.DiffStatus.MODIFIED]: "#DD7A00",
   };
 
   getHeader(label: string): string {
@@ -132,13 +142,18 @@ export class MermaidGenerator extends UmlGenerator {
 
   private getNodeLabel(node: DiagramNode): string {
     const icon = MermaidGenerator.ICON_MAP[node.icon] || "";
-    const diffStatus = node.diffStatus
-      ? `<span style='background-color:#FFFFFF;'> ${
-          MermaidGenerator.DIFF_STATUS_PREFIX_MAP[node.diffStatus]
-        }</span> `
-      : "";
+
+    // Create diff status indicator that matches GraphVizGenerator
+    let diffStatus = "";
+    if (node.diffStatus) {
+      const symbol = MermaidGenerator.DIFF_STATUS_SYMBOL_MAP[node.diffStatus];
+      const color = MermaidGenerator.DIFF_STATUS_COLOR_MAP[node.diffStatus];
+      // Add more horizontal padding around the diff indicator
+      diffStatus = `<span style='padding:6px;margin:6px;background-color:#FFFFFF;'><font color="${color}"><b>${symbol}</b></font></span>`;
+    }
+
     const sanitizedLabel = this.sanitizeLabel(node.label);
-    return `${diffStatus}${icon} <b>${node.type}</b> <br> <u>${sanitizedLabel}</u>`;
+    return `${diffStatus}<b>${node.type}</b> ${icon}<br> <u>${sanitizedLabel}</u>`;
   }
 
   private formatInnerNodeLabel(node: InnerNode): string {

--- a/src/test/mermaid_generator_test.ts
+++ b/src/test/mermaid_generator_test.ts
@@ -184,6 +184,7 @@ function generateDecision(name: string): flowTypes.FlowDecision {
   } as flowTypes.FlowDecision;
 }
 
+// @ts-ignore: Deno types
 Deno.test("MermaidGenerator", async (t) => {
   let systemUnderTest: MermaidGenerator;
   let mockedFlow: ParsedFlow;
@@ -215,7 +216,7 @@ Deno.test("MermaidGenerator", async (t) => {
       color: UmlSkinColor.NONE,
     };
     result = systemUnderTest.toUmlString(node);
-    assertStringIncludes(result, 'state "⚡ <b>Apex Plugin Call</b>');
+    assertStringIncludes(result, "<b>Apex Plugin Call</b> ⚡");
     assertStringIncludes(result, "as myApexPluginCall");
   });
 
@@ -228,7 +229,7 @@ Deno.test("MermaidGenerator", async (t) => {
       color: UmlSkinColor.ORANGE,
     };
     result = systemUnderTest.toUmlString(node);
-    assertStringIncludes(result, 'state "📝 <b>Assignment</b>');
+    assertStringIncludes(result, "<b>Assignment</b> 📝");
     assertStringIncludes(result, "as myAssignment");
     assertStringIncludes(result, "class myAssignment orange");
   });
@@ -260,7 +261,7 @@ Deno.test("MermaidGenerator", async (t) => {
       ],
     };
     result = systemUnderTest.toUmlString(node);
-    assertStringIncludes(result, 'state "🔹 <b>Decision</b>');
+    assertStringIncludes(result, "<b>Decision</b> 🔹");
     assertStringIncludes(result, "<b>Rule</b>");
     assertStringIncludes(result, "as myDecision");
     assertStringIncludes(result, "class myDecision orange");
@@ -278,7 +279,7 @@ Deno.test("MermaidGenerator", async (t) => {
     result = systemUnderTest.toUmlString(node);
     assertStringIncludes(
       result,
-      "<span style='background-color:#FFFFFF;'> ➕</span>"
+      "<span style='padding:6px;margin:6px;background-color:#FFFFFF;'><font color=\"green\"><b>+</b></font></span>"
     );
     assertStringIncludes(result, "class myNode pink");
   });


### PR DESCRIPTION
- Rename DIFF_STATUS_PREFIX_MAP to DIFF_STATUS_SYMBOL_MAP and update symbols for clarity.
- Introduce DIFF_STATUS_COLOR_MAP for color coding diff statuses.
- Update getNodeLabel method to improve diff status display with padding and color.
- Adjust unit tests to reflect changes in diff status formatting and ensure consistency.