### PR TITLE
Add Details to FlowRecordLookup nodes

### DIFF
--- a/src/main/graphviz_generator.ts
+++ b/src/main/graphviz_generator.ts
@@ -115,25 +115,19 @@ node [shape=box, style=filled]`;
       GraphVizGenerator.SKIN_COLOR_MAP[node.color] || SkinColor.NONE;
     const graphvizIcon = GraphVizGenerator.ICON_MAP[node.icon] || Icon.NONE;
 
-    // Handle nodes with inner nodes
-    if (node.innerNodes) {
-      return getNodeBody(
-        node,
-        node.type,
-        graphvizIcon,
-        graphvizSkinColor,
-        this.generateInnerNodeBodyFromInnerNodes(node, node.innerNodes)
-      );
-    }
-
-    // Handle regular nodes
-    return getNodeBody(node, node.type, graphvizIcon, graphvizSkinColor);
+    return getNodeBody(
+      node,
+      node.type,
+      graphvizIcon,
+      graphvizSkinColor,
+      this.generateInnerNodeBodyFromInnerNodes(node, node.innerNodes)
+    );
   }
 
   // Helper method to generate inner node body from DiagramNode's innerNodes
   generateInnerNodeBodyFromInnerNodes(
     parentNode: DiagramNode,
-    innerNodes: InnerNode[]
+    innerNodes?: InnerNode[]
   ): string {
     if (!innerNodes || innerNodes.length === 0) {
       return "";
@@ -145,6 +139,7 @@ node [shape=box, style=filled]`;
       const innerNodeBody = getInnerNodeBody(
         parentNode,
         FontColor.WHITE,
+        getLabel(innerNode.type),
         getLabel(innerNode.label),
         innerNode.content
       );
@@ -192,14 +187,16 @@ ${TABLE_END}`;
 function getInnerNodeBody(
   parentNode: DiagramNode,
   color: FontColor,
+  type: string,
   label: string,
   content: string[]
 ) {
+  const formattedLabel = getLabel([type, label].join(" "));
   return `  <TR>
     <TD${getColSpan(
       parentNode
     )} BORDER="1" COLOR="${color}" ALIGN="LEFT" CELLPADDING="6">
-      <B>${getLabel(label)}</B>
+      <B>${formattedLabel}</B>
       ${content.map((content) => `<BR ALIGN="LEFT"/>${content}`).join("")}
     </TD>
   </TR>`;

--- a/src/main/mermaid_generator.ts
+++ b/src/main/mermaid_generator.ts
@@ -161,8 +161,9 @@ export class MermaidGenerator extends UmlGenerator {
     const sanitizedContent = node.content.map((item) =>
       this.sanitizeLabel(item)
     );
-    return `<b>${
-      node.type
-    }</b> <br ><u>${sanitizedLabel}</u> <br>${sanitizedContent.join("<br>")}`;
+    const nodeType = node.type ? `<b>${node.type}</b><br>` : "";
+    const nodeLabel = node.label ? `<u>${sanitizedLabel}</u><br>` : "";
+    const nodeContent = sanitizedContent.join("<br>");
+    return `${nodeType}${nodeLabel}${nodeContent}`;
   }
 }

--- a/src/main/uml_generator.ts
+++ b/src/main/uml_generator.ts
@@ -318,7 +318,64 @@ export abstract class UmlGenerator {
       type: "Record Lookup",
       color: SkinColor.PINK,
       icon: Icon.LOOKUP,
+      innerNodes: this.getFlowRecordLookupInnerNodes(node),
     });
+  }
+
+  private getFlowRecordLookupInnerNodes(
+    node: flowTypes.FlowRecordLookup
+  ): InnerNode[] {
+    const innerNodeContent: string[] = [];
+    innerNodeContent.push(...this.getFieldsQueried(node));
+    innerNodeContent.push(...this.getFilterCriteria(node));
+    const limit = this.getLimit(node);
+    if (limit) {
+      innerNodeContent.push(limit);
+    }
+
+    let innerNode = {
+      id: `${node.name}__LookupDetails`,
+      type: `sObject: ${node.object}`,
+      label: "",
+      content: innerNodeContent,
+    };
+    return [innerNode];
+  }
+
+  private getFieldsQueried(node: flowTypes.FlowRecordLookup): string[] {
+    const result: string[] = [];
+    if (node.queriedFields && node.queriedFields.length > 0) {
+      result.push("Fields Queried:");
+      result.push(node.queriedFields.join(", "));
+    } else {
+      result.push("Fields Queried: all");
+    }
+    return result;
+  }
+
+  private getFilterCriteria(node: flowTypes.FlowRecordLookup): string[] {
+    const result: string[] = [
+      `Filter Logic: ${node.filterLogic ? node.filterLogic : "None"}`,
+    ];
+    const filters = node.filters?.map((filter, index) => {
+      return `${index + 1}. ${filter.field} ${filter.operator} ${toString(
+        filter.value
+      )}`;
+    });
+    if (filters) {
+      result.push(...filters);
+    }
+    return result;
+  }
+
+  private getLimit(node: flowTypes.FlowRecordLookup): string {
+    if (node.getFirstRecordOnly) {
+      return "Limit: First Record Only";
+    }
+    if (node.limit) {
+      return `Limit: ${node.limit}`;
+    }
+    return "Limit: All Records";
   }
 
   private getFlowRecordRollback(node: flowTypes.FlowRecordRollback): string {

--- a/src/test/graphviz_generator_test.ts
+++ b/src/test/graphviz_generator_test.ts
@@ -312,7 +312,7 @@ Deno.test("GraphViz", async (t) => {
         Icon.DECISION,
         SkinColor.ORANGE,
         FontColor.WHITE,
-        generateInnerNodeCell(FontColor.WHITE, "myDecisionRule", [
+        generateInnerNodeCell(FontColor.WHITE, "Rule myDecisionRule", [
           "1. foo EqualTo true",
         ])
       )
@@ -351,8 +351,8 @@ Deno.test("GraphViz", async (t) => {
         SkinColor.NAVY,
         FontColor.WHITE,
         generateInnerNodeCells([
-          generateInnerNodeCell(FontColor.WHITE, "1. step1", []),
-          generateInnerNodeCell(FontColor.WHITE, "2. step2", []),
+          generateInnerNodeCell(FontColor.WHITE, "Stage Step 1. step1", []),
+          generateInnerNodeCell(FontColor.WHITE, "Stage Step 2. step2", []),
         ])
       )
     );


### PR DESCRIPTION
- Introduce methods to generate inner node content for FlowRecordLookup, including fields queried, filter criteria, and limits.
- Update UML representation to include inner node details in the generated output.
- Enhance tests to validate the correct generation of UML for FlowRecordLookup nodes with various configurations.