### PR TITLE
Minimize Github Comment Footprint

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@goog/flow-lens",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "Apache",
   "exports": "./src/main/main.ts",
   "imports": {

--- a/src/main/github_client.ts
+++ b/src/main/github_client.ts
@@ -22,12 +22,66 @@
 import { Octokit } from "@octokit/core";
 import { context as githubContext } from "@actions/github";
 
+export const ERROR_MESSAGES = {
+  NOT_PR_CONTEXT: "Not running in a pull request context",
+  MISSING_PR_NUMBER: "Cannot write comment: Pull request number is missing",
+  MISSING_PR_SHA: "Cannot write comment: Pull request head SHA is missing",
+  FETCH_COMMENTS_FAILED: (error: string) =>
+    `Failed to fetch pull request review comments: ${error}`,
+};
+
 export type GithubComment = {
   commit_id: string;
   path: string;
   subject_type: "file";
   body: string;
 };
+
+/**
+ * Represents a review comment on a pull request.
+ * @see https://docs.github.com/en/rest/pulls/comments
+ */
+export interface PullRequestReviewComment {
+  url: string;
+  pull_request_review_id: number;
+  id: number;
+  node_id: string;
+  diff_hunk: string;
+  path: string;
+  position: number;
+  original_position: number;
+  commit_id: string;
+  original_commit_id: string;
+  in_reply_to_id?: number;
+  user: {
+    login: string;
+    id: number;
+    node_id: string;
+    avatar_url: string;
+    gravatar_id: string;
+    url: string;
+    html_url: string;
+    type: string;
+    site_admin: boolean;
+  };
+  body: string;
+  created_at: string;
+  updated_at: string;
+  html_url: string;
+  pull_request_url: string;
+  author_association: string;
+  _links: {
+    self: { href: string };
+    html: { href: string };
+    pull_request: { href: string };
+  };
+  start_line?: number;
+  original_start_line?: number;
+  start_side?: string;
+  line?: number;
+  original_line?: number;
+  side?: string;
+}
 
 export class GithubClient {
   private readonly octokit: Octokit;
@@ -40,12 +94,12 @@ export class GithubClient {
 
   async writeComment(comment: GithubComment) {
     if (!this.context.payload.pull_request) {
-      throw new Error("Cannot write comment: Not in a pull request context");
+      throw new Error(ERROR_MESSAGES.NOT_PR_CONTEXT);
     }
 
     const pullRequestNumber = this.context.payload.pull_request.number;
     if (!pullRequestNumber) {
-      throw new Error("Cannot write comment: Pull request number is missing");
+      throw new Error(ERROR_MESSAGES.MISSING_PR_NUMBER);
     }
 
     const endpoint = `POST /repos/${this.context.repo.owner}/${this.context.repo.repo}/pulls/${pullRequestNumber}/comments`;
@@ -54,11 +108,11 @@ export class GithubClient {
 
   translateToComment(body: string, filePath: string): GithubComment {
     if (!this.context.payload.pull_request) {
-      throw new Error("Cannot write comment: Not in a pull request context");
+      throw new Error(ERROR_MESSAGES.NOT_PR_CONTEXT);
     }
     const sha = this.context.payload.pull_request.head.sha;
     if (!sha) {
-      throw new Error("Cannot write comment: Pull request head SHA is missing");
+      throw new Error(ERROR_MESSAGES.MISSING_PR_SHA);
     }
     return {
       commit_id: sha,
@@ -66,5 +120,37 @@ export class GithubClient {
       subject_type: "file",
       body: body,
     };
+  }
+
+  /**
+   * Retrieves all review comments for the current pull request.
+   * These are comments made on specific lines of code in the pull request.
+   *
+   * @throws Error if not running in a pull request context
+   * @returns Array of pull request review comments
+   */
+  async getAllCommentsForPullRequest(): Promise<
+    Array<PullRequestReviewComment>
+  > {
+    const prNumber = this.context.payload.pull_request?.number;
+    if (!prNumber) {
+      throw new Error(ERROR_MESSAGES.NOT_PR_CONTEXT);
+    }
+
+    const owner = this.context.repo.owner;
+    const repo = this.context.repo.repo;
+
+    try {
+      const response = await this.octokit.request(
+        `GET /repos/${owner}/${repo}/pulls/${prNumber}/comments`
+      );
+      return response.data;
+    } catch (error) {
+      throw new Error(
+        ERROR_MESSAGES.FETCH_COMMENTS_FAILED(
+          error instanceof Error ? error.message : "Unknown error"
+        )
+      );
+    }
   }
 }

--- a/src/main/uml_writer.ts
+++ b/src/main/uml_writer.ts
@@ -110,21 +110,25 @@ function getFormatter(): Formatter {
 
 function getBody(flowDifference: FlowDifference) {
   const oldDiagram = flowDifference.old
-    ? `Old Version:
+    ? `<details>
+<summary>Old Version</summary>
+
 ${MERMAID_OPEN_TAG}
 ${flowDifference.old}
 ${MERMAID_CLOSE_TAG}
+</details>
 
-  `
+`
     : "";
 
-  const newDiagram = `New Version:
+  const newDiagram = `<details open>
+<summary>New Version</summary>
+
 ${MERMAID_OPEN_TAG}
 ${flowDifference.new}
 ${MERMAID_CLOSE_TAG}
-  `;
+</details>`;
 
   return `${HIDDEN_COMMENT_PREFIX}
-${oldDiagram}
-${newDiagram}`;
+${oldDiagram}${newDiagram}`;
 }

--- a/src/main/uml_writer.ts
+++ b/src/main/uml_writer.ts
@@ -22,7 +22,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { Configuration, Mode, RuntimeConfig } from "./argument_processor.ts";
 import { FlowDifference } from "./flow_to_uml_transformer.ts";
-import { GithubClient, GithubComment } from "./github_client.ts";
+import { GithubClient } from "./github_client.ts";
 
 const FILE_EXTENSION = ".json";
 const HIDDEN_COMMENT_PREFIX = "<!--flow-lens-hidden-comment-->";
@@ -43,12 +43,12 @@ export class UmlWriter {
   /**
    * Writes the UML diagrams to a file.
    */
-  writeUmlDiagrams() {
+  async writeUmlDiagrams() {
     const config = Configuration.getInstance();
     if (config.mode === Mode.JSON) {
       this.writeJsonFile(config);
     } else if (config.mode === Mode.GITHUB_ACTION) {
-      this.writeGithubComment(config);
+      await this.writeGithubComment(config);
     }
   }
 
@@ -63,14 +63,30 @@ export class UmlWriter {
     );
   }
 
-  private writeGithubComment(config: RuntimeConfig) {
-    this.filePathToFlowDifference.forEach((flowDifference, filePath) => {
-      const comment = this.githubClient.translateToComment(
-        getBody(flowDifference),
-        filePath
+  private async writeGithubComment(config: RuntimeConfig) {
+    try {
+      const existingComments =
+        await this.githubClient.getAllCommentsForPullRequest();
+
+      const flowLensComments = existingComments.filter((comment) =>
+        comment.body.includes(HIDDEN_COMMENT_PREFIX)
       );
-      this.githubClient.writeComment(comment);
-    });
+
+      for (const comment of flowLensComments) {
+        await this.githubClient.deleteReviewComment(comment.id);
+      }
+
+      for (const [filePath, flowDifference] of this.filePathToFlowDifference) {
+        const comment = this.githubClient.translateToComment(
+          getBody(flowDifference),
+          filePath
+        );
+        await this.githubClient.writeComment(comment);
+      }
+    } catch (error) {
+      console.error("Failed to update GitHub comments:", error);
+      throw error;
+    }
   }
 }
 

--- a/src/main/uml_writer.ts
+++ b/src/main/uml_writer.ts
@@ -29,6 +29,10 @@ const HIDDEN_COMMENT_PREFIX = "<!--flow-lens-hidden-comment-->";
 const MERMAID_OPEN_TAG = "```mermaid";
 const MERMAID_CLOSE_TAG = "```";
 
+const getGithubCommentSummary = (version: "old" | "new"): string => {
+  return `<summary>Click here to view a preview of the ${version} version of this flow</summary>`;
+};
+
 /**
  * This class is used to write the generated UML diagrams to a file.
  */
@@ -127,7 +131,7 @@ function getFormatter(): Formatter {
 function getBody(flowDifference: FlowDifference) {
   const oldDiagram = flowDifference.old
     ? `<details>
-<summary>Old Version</summary>
+${getGithubCommentSummary("old")}
 
 ${MERMAID_OPEN_TAG}
 ${flowDifference.old}
@@ -137,8 +141,8 @@ ${MERMAID_CLOSE_TAG}
 `
     : "";
 
-  const newDiagram = `<details open>
-<summary>New Version</summary>
+  const newDiagram = `<details>
+${getGithubCommentSummary("new")}
 
 ${MERMAID_OPEN_TAG}
 ${flowDifference.new}


### PR DESCRIPTION
- Automatically deletes previously generated diagrams when PRs are updated, then posts freshly generated diagrams.
- Renders diagrams in a section which is collapsed by default with the label `Click here to view a preview of the [old/new] version of this flow`. 
- Fixes #28 