### PR TITLE
Add detail to record updates in UML generation

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@goog/flow-lens",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "Apache",
   "exports": "./src/main/main.ts",
   "imports": {

--- a/src/main/flow_parser.ts
+++ b/src/main/flow_parser.ts
@@ -149,6 +149,7 @@ export class FlowParser {
     setRecordLookups(this.beingParsed.recordLookups);
     this.beingParsed.recordRollbacks = ensureArray(flow.recordRollbacks);
     this.beingParsed.recordUpdates = ensureArray(flow.recordUpdates);
+    setRecordUpdates(this.beingParsed.recordUpdates);
     this.beingParsed.screens = ensureArray(flow.screens);
     this.beingParsed.steps = ensureArray(flow.steps);
     this.beingParsed.subflows = ensureArray(flow.subflows);
@@ -505,6 +506,26 @@ function setRecordLookups(
       ) as string[];
     }
   });
+}
+
+/**
+ * Ensures that filters and inputAssignments are arrays in record update nodes
+ */
+function setRecordUpdates(
+  recordUpdates: flowTypes.FlowRecordUpdate[] | undefined
+) {
+  if (!recordUpdates) {
+    return;
+  }
+  for (const recordUpdate of recordUpdates) {
+    recordUpdate.filters = ensureArray(
+      recordUpdate.filters ?? []
+    ) as flowTypes.FlowRecordFilter[];
+
+    recordUpdate.inputAssignments = ensureArray(
+      recordUpdate.inputAssignments ?? []
+    ) as flowTypes.FlowInputFieldAssignment[];
+  }
 }
 
 /**

--- a/src/main/uml_generator.ts
+++ b/src/main/uml_generator.ts
@@ -397,7 +397,48 @@ export abstract class UmlGenerator {
       type: "Record Update",
       color: SkinColor.PINK,
       icon: Icon.UPDATE,
+      innerNodes: this.getFlowRecordUpdateInnerNodes(node),
     });
+  }
+
+  private getFlowRecordUpdateInnerNodes(
+    node: flowTypes.FlowRecordUpdate
+  ): InnerNode[] {
+    const innerNodeContent: string[] = [];
+
+    if (node.filters && node.filters.length > 0) {
+      innerNodeContent.push("Filter Criteria:");
+      node.filters.forEach((filter, index) => {
+        innerNodeContent.push(
+          `${index + 1}. ${filter.field} ${filter.operator} ${toString(
+            filter.value
+          )}`
+        );
+      });
+    }
+
+    if (node.inputAssignments && node.inputAssignments.length > 0) {
+      innerNodeContent.push("Field Updates:");
+      node.inputAssignments.forEach((assignment) => {
+        innerNodeContent.push(
+          `${assignment.field} = ${toString(assignment.value)}`
+        );
+      });
+    }
+
+    const type = node.inputReference ? "Reference Update" : "Direct Update";
+    const label = node.inputReference
+      ? node.inputReference
+      : `sObject: ${node.object}`;
+
+    return [
+      {
+        id: `${node.name}__UpdateDetails`,
+        type: type,
+        label: label,
+        content: innerNodeContent,
+      },
+    ];
   }
 
   private getFlowScreen(node: flowTypes.FlowScreen): string {


### PR DESCRIPTION
- Introduce setRecordUpdates function to ensure filters and inputAssignments are arrays in FlowRecordUpdate nodes.
- Enhance UmlGenerator to generate inner node content for FlowRecordUpdate, including filter criteria and field updates.
- Update UML representation to include detailed inner node information for record updates.
- Add tests to validate the correct generation of UML for FlowRecordUpdate nodes with various configurations.